### PR TITLE
ci: use bun ci and npm publish in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.determine.outputs.changed == 'true' && steps.determine.outputs.tag_exists == 'false'
-        run: bun install
+        run: bun ci
 
       - name: Generate release notes
         if: steps.determine.outputs.changed == 'true' && steps.determine.outputs.tag_exists == 'false'
@@ -129,4 +129,4 @@ jobs:
 
       - name: Publish to npm
         if: steps.determine.outputs.changed == 'true' && steps.determine.outputs.tag_exists == 'false'
-        run: bunx npm publish --access public --provenance
+        run: npm publish --access public --provenance


### PR DESCRIPTION
Use 'bun ci' instead of 'bun install' for faster, lockfile-based
dependency installation in CI environments.

Use 'npm publish' directly instead of 'bunx npm publish' to ensure
proper support for provenance in npm publishing.
