### PR TITLE
fix: bump bun-pty to ^0.4.10 and export server for PluginModule conformance

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@opencode-ai/plugin": "^1.3.13",
         "@opencode-ai/sdk": "^1.3.13",
-        "bun-pty": "^0.4.8",
+        "bun-pty": "^0.4.10",
         "open": "^11.0.0",
       },
       "devDependencies": {
@@ -277,7 +277,7 @@
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
-    "bun-pty": ["bun-pty@0.4.8", "", {}, "sha512-rO70Mrbr13+jxHHHu2YBkk2pNqrJE5cJn29WE++PUr+GFA0hq/VgtQPZANJ8dJo6d7XImvBk37Innt8GM7O28w=="],
+    "bun-pty": ["bun-pty@0.4.10", "", {}, "sha512-7WFtCw9MwG9gMMvkX+pwUOavNbgmfL+masMWmO9d/HdFCz8VdR+5G4Q3UCLhy2OJ/ImbWuJ1FHFmm0KdgW102w=="],
 
     "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
 

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,2 @@
 export { PTYPlugin } from './src/plugin.ts'
+export { PTYPlugin as server } from './src/plugin.ts'

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   "dependencies": {
     "@opencode-ai/plugin": "^1.3.13",
     "@opencode-ai/sdk": "^1.3.13",
-    "bun-pty": "^0.4.8",
+    "bun-pty": "^0.4.10",
     "open": "^11.0.0"
   }
 }


### PR DESCRIPTION
## Summary

Two fixes that together make `opencode-pty` work correctly with opencode's current plugin runtime.

### 1. Bump bun-pty to ^0.4.10

bun-pty 0.4.8 treated transient PTY read errors (EINTR, EWOULDBLOCK) as EOF, causing the reader thread to flip the PTY into an exited state while the child process was still alive. A SIGCHLD or similar signal during a read syscall produced EINTR, which the reader misinterpreted as EOF. PTY sessions then reported exit code 0 after a few seconds even for long-running commands like `sleep 60`.

Fixed in bun-pty 0.4.9: *"Don't treat transient PTY read/write errors (EINTR/EWOULDBLOCK) as EOF"*

### 2. Export PTYPlugin as `server`

opencode's plugin loader expects modules to satisfy the `PluginModule` type:

```ts
type PluginModule = { id?: string; server: Plugin; tui?: never }
```

The package only exported `PTYPlugin` (named export), which opencode does not recognise as a valid plugin entry point. As a result the plugin loaded silently but registered no tools and no slash commands.

Adding `export { PTYPlugin as server }` makes the module conform to `PluginModule` while preserving the existing `PTYPlugin` export for users who import it directly.

Closes #40
