### PR TITLE
chore: release 0.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "dist/index.js",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "OpenCode plugin for interactive PTY management - run background processes, send input, read output with regex filtering",
   "author": "shekohex",
   "keywords": [


### PR DESCRIPTION
## Summary
- Bump package version to 0.3.5 so the existing release workflow publishes current main.
- Current main already contains the bun-pty 0.4.10 compatibility fixes after v0.3.4; npm latest is still v0.3.4.

## Why
- The published npm package can fail to load when installed as an opencode npm plugin spec such as `opencode-pty@latest`.
- v0.3.4 allows newer `bun-pty` versions through its dependency range, but the published runtime still throws when `bun-pty > 0.4.8`: `bun-pty version ... is too new for patching; remove the workaround.`
- As a result, opencode sees the plugin origin but the plugin module import fails before PTY commands/tools are registered.
- Main has already removed that guard and moved to `bun-pty ^0.4.10`, so publishing a new version should make npm-spec installs pick up the fixed code.

## Verification
- `bun ci`
- `bun run build:plugin`
- `bun run typecheck`
- `bun -e "const m = await import('./dist/index.js'); console.log(JSON.stringify(Object.keys(m)), typeof m.PTYPlugin)"`
- `bun test test/types.test.ts test/pty-tools.test.ts`

Note: full `bun run unittest` was also attempted on Windows and failed due existing Windows/environment issues (`rm` not found and PTY spawn failed), unrelated to this version-only change.