### PR TITLE
fix: preserve model for exit notifications

### DIFF
--- a/src/plugin/pty/notification-manager.ts
+++ b/src/plugin/pty/notification-manager.ts
@@ -16,11 +16,36 @@ export class NotificationManager {
 
     try {
       const message = this.buildExitNotification(session, exitCode)
+      let modelContext: {
+        model?: { providerID: string; modelID: string }
+        variant?: string
+      } = {}
+      try {
+        const parent = await this.client.session.get({
+          path: { id: session.parentSessionId },
+        })
+        const model = (
+          parent.data as
+            | (typeof parent.data & {
+                model?: { id: string; providerID: string; variant?: string }
+              })
+            | undefined
+        )?.model
+        if (model) {
+          modelContext = {
+            model: { providerID: model.providerID, modelID: model.id },
+            ...(model.variant ? { variant: model.variant } : {}),
+          }
+        }
+      } catch {
+        // Older OpenCode versions may not expose the session model.
+      }
       await this.client.session.promptAsync({
         path: { id: session.parentSessionId },
         body: {
           parts: [{ type: 'text', text: message }],
           ...(session.parentAgent ? { agent: session.parentAgent } : {}),
+          ...modelContext,
         },
       })
     } catch {

--- a/test/notification-manager.test.ts
+++ b/test/notification-manager.test.ts
@@ -9,6 +9,8 @@ type PromptPayload = {
   body: {
     parts: Array<{ type: string; text: string }>
     agent?: string
+    model?: { providerID: string; modelID: string }
+    variant?: string
   }
 }
 
@@ -38,6 +40,67 @@ function createSession(overrides: Partial<PTYSession> = {}): PTYSession {
 }
 
 describe('NotificationManager', () => {
+  it('preserves the parent session model and variant', async () => {
+    const get = mock(async () => ({
+      data: {
+        model: { providerID: 'openai', id: 'gpt-5.6-terra', variant: 'high' },
+      },
+    }))
+    const promptAsync = mock(async (_payload: PromptPayload) => {})
+    const manager = new NotificationManager()
+
+    manager.init({ session: { get, promptAsync } } as unknown as OpencodeClient)
+
+    await manager.sendExitNotification(createSession(), 0)
+
+    expect(get).toHaveBeenCalledWith({ path: { id: 'parent-session-id' } })
+    const payload = promptAsync.mock.calls[0]?.[0]
+    if (!payload) throw new Error('Expected a prompt payload')
+    expect(payload.body.model).toEqual({
+      providerID: 'openai',
+      modelID: 'gpt-5.6-terra',
+    })
+    expect(payload.body.variant).toBe('high')
+  })
+
+  it('preserves the parent model without inventing a variant', async () => {
+    const get = mock(async () => ({
+      data: { model: { providerID: 'openai', id: 'gpt-5.6-terra' } },
+    }))
+    const promptAsync = mock(async (_payload: PromptPayload) => {})
+    const manager = new NotificationManager()
+
+    manager.init({ session: { get, promptAsync } } as unknown as OpencodeClient)
+
+    await manager.sendExitNotification(createSession(), 0)
+
+    const payload = promptAsync.mock.calls[0]?.[0]
+    if (!payload) throw new Error('Expected a prompt payload')
+    expect(payload.body.model).toEqual({
+      providerID: 'openai',
+      modelID: 'gpt-5.6-terra',
+    })
+    expect(Object.hasOwn(payload.body, 'variant')).toBe(false)
+  })
+
+  it('sends the notification when reading the parent model fails', async () => {
+    const get = mock(async () => {
+      throw new Error('Session API unavailable')
+    })
+    const promptAsync = mock(async (_payload: PromptPayload) => {})
+    const manager = new NotificationManager()
+
+    manager.init({ session: { get, promptAsync } } as unknown as OpencodeClient)
+
+    await manager.sendExitNotification(createSession(), 0)
+
+    expect(promptAsync).toHaveBeenCalledTimes(1)
+    const payload = promptAsync.mock.calls[0]?.[0]
+    if (!payload) throw new Error('Expected a prompt payload')
+    expect(Object.hasOwn(payload.body, 'model')).toBe(false)
+    expect(Object.hasOwn(payload.body, 'variant')).toBe(false)
+  })
+
   it('includes body.agent when originating agent is present', async () => {
     const promptAsync = mock(async (_payload: PromptPayload) => {})
     const manager = new NotificationManager()
@@ -47,7 +110,8 @@ describe('NotificationManager', () => {
     await manager.sendExitNotification(createSession({ parentAgent: 'agent-two' }), 0)
 
     expect(promptAsync).toHaveBeenCalledTimes(1)
-    const payload = promptAsync.mock.calls[0]![0]
+    const payload = promptAsync.mock.calls[0]?.[0]
+    if (!payload) throw new Error('Expected a prompt payload')
 
     expect(payload.path).toEqual({ id: 'parent-session-id' })
     expect(payload.body.agent).toBe('agent-two')
@@ -65,7 +129,8 @@ describe('NotificationManager', () => {
     await manager.sendExitNotification(createSession({ parentAgent: undefined }), 1)
 
     expect(promptAsync).toHaveBeenCalledTimes(1)
-    const payload = promptAsync.mock.calls[0]![0]
+    const payload = promptAsync.mock.calls[0]?.[0]
+    if (!payload) throw new Error('Expected a prompt payload')
 
     expect(payload.path).toEqual({ id: 'parent-session-id' })
     expect(Object.hasOwn(payload.body, 'agent')).toBe(false)
@@ -85,7 +150,8 @@ describe('NotificationManager', () => {
     await manager.sendExitNotification(createSession({ timeoutSeconds: 2, timedOut: true }), 0)
 
     expect(promptAsync).toHaveBeenCalledTimes(1)
-    const payload = promptAsync.mock.calls[0]![0]
+    const payload = promptAsync.mock.calls[0]?.[0]
+    if (!payload) throw new Error('Expected a prompt payload')
     const text = payload.body.parts[0]?.text ?? ''
 
     expect(text).toContain('TimeoutSeconds: 2')


### PR DESCRIPTION
## Summary

- read the parent session's current model before sending a PTY exit notification
- pass its provider, model ID, and variant to `promptAsync`
- retain the existing notification behavior when an older OpenCode server does not expose `Session.model`

## Problem

`sendExitNotification()` currently passes the originating agent but omits the model and variant. OpenCode resolves a prompt without an explicit model as:

```ts
input.model ?? agent.model ?? currentModel(sessionID)
```

If the agent's configured default differs from the model selected for the current session, the generated `<pty_exited>` user turn switches the session to that default. All subsequent assistant turns then use the wrong model.

This uses only the standard OpenCode `session.get` and `promptAsync` APIs. It does not depend on another plugin. The local compatibility cast is needed because the package's pinned SDK type predates the runtime `Session.model` field.

## Verification

- `bun test test/notification-manager.test.ts`
- `bun typecheck`
- `bun lint`
- `bun format`
- fork CI: unit tests, E2E tests, typecheck, lint, format, and Nix checks
- live OpenCode 1.18.3 run: a `gpt-5.6-terra/high` session received a `<pty_exited>` notification and retained `gpt-5.6-terra/high` on the notification user message, subsequent assistant messages, and session summary
