### PR TITLE
feat: add pty_wait tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ opencode
 | `pty_read`  | Read output buffer with pagination and optional regex filtering             |
 | `pty_list`  | List all PTY sessions with status, PID, line count                          |
 | `pty_kill`  | Terminate a PTY, optionally cleanup the buffer                              |
+| `pty_wait`  | Block until a PTY session exits, optionally with a timeout                  |
 
 ## Slash Commands
 
@@ -224,6 +225,31 @@ Use pty_read to check the full output.
 ```
 
 This eliminates the need for polling—perfect for long-running processes like builds, tests, or deployment scripts. If the process fails (non-zero exit code), the notification will suggest using `pty_read` with the `pattern` parameter to search for errors.
+
+### Wait for a session to finish
+
+Exit notifications require the agent to go idle and wait for the `<pty_exited>` message.
+```
+pty_spawn: command="npm", args=["run", "build"], title="Build"
+→ Returns: pty_a1b2c3d4
+
+pty_wait: id="pty_a1b2c3d4"
+→ Returns once the build finishes (or <pty_wait_timeout> after timeoutSeconds)
+```
+
+```xml
+<pty_waited>
+ID: pty_a1b2c3d4
+Title: Build
+Command: npm run build
+Status: exited
+Exit: 0
+Output Lines: 42
+Tail: ...
+</pty_waited>
+```
+
+Use when the agent cannot go idle—for example when a `/goal` plugin auto-resumes idle agents, or when a subagent's parent interprets idleness as task completion.
 
 ## Configuration
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -6,6 +6,7 @@ import { ptyWrite } from './plugin/pty/tools/write.ts'
 import { ptyRead } from './plugin/pty/tools/read.ts'
 import { ptyList } from './plugin/pty/tools/list.ts'
 import { ptyKill } from './plugin/pty/tools/kill.ts'
+import { ptyWait } from './plugin/pty/tools/wait.ts'
 import { PTYServer } from './web/server/server.ts'
 import open from 'open'
 
@@ -50,6 +51,7 @@ export const PTYPlugin = async ({ client, directory }: PluginContext): Promise<P
       pty_read: ptyRead,
       pty_list: ptyList,
       pty_kill: ptyKill,
+      pty_wait: ptyWait,
     },
     config: async (input) => {
       if (!input.command) {

--- a/src/plugin/pty/manager.ts
+++ b/src/plugin/pty/manager.ts
@@ -33,7 +33,7 @@ export function removeSessionUpdateCallback(callback: SessionUpdateCallback) {
 }
 
 function notifySessionUpdate(session: PTYSessionInfo) {
-  for (const callback of sessionUpdateCallbacks) {
+  for (const callback of [...sessionUpdateCallbacks]) {
     try {
       callback(session)
     } catch {

--- a/src/plugin/pty/tools/wait.ts
+++ b/src/plugin/pty/tools/wait.ts
@@ -1,0 +1,122 @@
+import { tool } from '@opencode-ai/plugin'
+import { manager, registerSessionUpdateCallback, removeSessionUpdateCallback } from '../manager.ts'
+import { MAX_LINE_LENGTH } from '../../../shared/constants.ts'
+import { buildSessionNotFoundError } from '../utils.ts'
+import { formatLine } from '../formatters.ts'
+import type { PTYSessionInfo } from '../types.ts'
+import DESCRIPTION from './wait.txt'
+
+const WAIT_TAIL_LINES = 20
+const TIMEOUT = Symbol('pty_wait_timeout')
+
+function isTerminal(session: PTYSessionInfo): boolean {
+  return session.status === 'exited' || session.status === 'killed'
+}
+
+/**
+ * Reads the tail of a session's buffer as formatted lines.
+ */
+function formatTail(session: PTYSessionInfo, count: number): string[] {
+  const offset = Math.max(0, session.lineCount - count)
+  const result = manager.read(session.id, offset, count)
+  if (!result || result.lines.length === 0) {
+    return []
+  }
+  return result.lines.map((line, index) =>
+    formatLine(line, result.offset + index + 1, MAX_LINE_LENGTH)
+  )
+}
+
+function formatWaitedBlock(session: PTYSessionInfo): string {
+  const tail = formatTail(session, WAIT_TAIL_LINES)
+  const exitInfo = `${session.exitCode ?? 'unknown'}${session.exitSignal ? `, signal: ${session.exitSignal}` : ''}`
+  return [
+    `<pty_waited>`,
+    `ID: ${session.id}`,
+    `Title: ${session.title}`,
+    `Command: ${session.command} ${session.args.join(' ')}`,
+    `Status: ${session.status}`,
+    `Exit: ${exitInfo}`,
+    `Output Lines: ${session.lineCount}`,
+    ...(tail.length > 0 ? ['', 'Tail:', ...tail] : []),
+    `</pty_waited>`,
+  ].join('\n')
+}
+
+export const ptyWait = tool({
+  description: DESCRIPTION,
+  args: {
+    id: tool.schema.string().describe('The PTY session ID (e.g., pty_a1b2c3d4)'),
+    timeoutSeconds: tool.schema
+      .number()
+      .optional()
+      .describe(
+        'Maximum time to wait in seconds. If the session is still running after this, returns a <pty_wait_timeout> result instead of blocking forever. Default: no limit.'
+      ),
+  },
+  async execute(args) {
+    const initial = manager.get(args.id)
+    if (!initial) {
+      throw buildSessionNotFoundError(args.id)
+    }
+    if (isTerminal(initial)) {
+      return formatWaitedBlock(initial)
+    }
+
+    let resolveDone!: (session: PTYSessionInfo) => void
+    const done = new Promise<PTYSessionInfo>((resolve) => {
+      resolveDone = resolve
+    })
+
+    const onUpdate = (updated: PTYSessionInfo): void => {
+      if (updated.id !== args.id || !isTerminal(updated)) {
+        return
+      }
+      removeSessionUpdateCallback(onUpdate)
+      resolveDone(updated)
+    }
+    registerSessionUpdateCallback(onUpdate)
+
+    // Close the race window between the initial get and registration.
+    const recheck = manager.get(args.id)
+    if (!recheck) {
+      removeSessionUpdateCallback(onUpdate)
+      throw buildSessionNotFoundError(args.id)
+    }
+    if (isTerminal(recheck)) {
+      removeSessionUpdateCallback(onUpdate)
+      resolveDone(recheck)
+    }
+
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined
+    const timeoutSeconds = args.timeoutSeconds
+    let timeout: Promise<typeof TIMEOUT>
+    if (timeoutSeconds === undefined) {
+      timeout = new Promise<typeof TIMEOUT>(() => {})
+    } else {
+      timeout = new Promise<typeof TIMEOUT>((resolve) => {
+        timeoutHandle = setTimeout(
+          () => {
+            removeSessionUpdateCallback(onUpdate)
+            resolve(TIMEOUT)
+          },
+          Math.max(0, Math.floor(timeoutSeconds * 1000))
+        )
+      })
+    }
+
+    const winner = await Promise.race([done, timeout])
+    if (timeoutHandle !== undefined) {
+      clearTimeout(timeoutHandle)
+    }
+    if (winner === TIMEOUT) {
+      return [
+        `<pty_wait_timeout>`,
+        `Session is still running after ${Math.max(0, args.timeoutSeconds ?? 0)}s.`,
+        `Use pty_read for live output, pty_kill to stop it, or call pty_wait again with a longer timeout.`,
+        `</pty_wait_timeout>`,
+      ].join('\n')
+    }
+    return formatWaitedBlock(winner)
+  },
+})

--- a/src/plugin/pty/tools/wait.txt
+++ b/src/plugin/pty/tools/wait.txt
@@ -1,0 +1,17 @@
+Waits for a PTY session to finish running and returns once it has completed.
+
+Use this tool when you cannot go idle and wait for the `<pty_exited>` completion message, e.g., when
+- Used with a `/goal` plugin which automatically resumes idle agents
+- Used by a subagent whose parent interprets idleness as task completion
+
+Usage:
+- `id`: The PTY session ID (from `pty_spawn` or `pty_list`)
+- `timeoutSeconds`: Optional. Maximum time to wait in seconds. If the session is still running after this, returns a `<pty_wait_timeout>` result instead of blocking forever. Default: no limit.
+
+Returns `<pty_waited>` block with the final status, exit code, and the last 20
+lines of output (tail). If the session already exited, returns immediately.
+
+Tips:
+- Combine with `pty_spawn` (with or without notifyOnExit) to run a command and wait.
+- After a timeout result, call `pty_read` for live output, `pty_kill` to stop the session, or call `pty_wait` again with a longer timeout.
+- Prefer this over sleep plus `pty_read` polling loops.

--- a/test/pty-tools.test.ts
+++ b/test/pty-tools.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect, beforeEach, mock, spyOn, afterAll } from 'bun:tes
 import { ptySpawn } from '../src/plugin/pty/tools/spawn.ts'
 import { ptyRead } from '../src/plugin/pty/tools/read.ts'
 import { ptyList } from '../src/plugin/pty/tools/list.ts'
+import { ptyWait } from '../src/plugin/pty/tools/wait.ts'
 import { RingBuffer } from '../src/plugin/pty/buffer.ts'
-import { manager } from '../src/plugin/pty/manager.ts'
+import { manager, sessionUpdateCallbacks } from '../src/plugin/pty/manager.ts'
+import type { PTYSessionInfo } from '../src/plugin/pty/types.ts'
 
 describe('PTY Tools', () => {
   afterAll(() => {
@@ -346,6 +348,146 @@ describe('PTY Tools', () => {
       )
 
       expect(result).toBe('<pty_list>\nNo active PTY sessions.\n</pty_list>')
+    })
+  })
+
+  describe('ptyWait', () => {
+    function makeSession(overrides: Partial<PTYSessionInfo> = {}): PTYSessionInfo {
+      return {
+        id: 'test-session-id',
+        title: 'Test Session',
+        description: 'A session for testing',
+        command: 'echo',
+        args: ['hello'],
+        workdir: '/tmp',
+        status: 'exited',
+        notifyOnExit: false,
+        timeoutSeconds: undefined,
+        timedOut: false,
+        exitCode: 0,
+        pid: 12345,
+        createdAt: new Date().toISOString(),
+        lineCount: 2,
+        ...overrides,
+      } as PTYSessionInfo
+    }
+
+    const ctx = {
+      sessionID: 'parent',
+      messageID: 'msg',
+      agent: 'agent',
+      abort: new AbortController().signal,
+      metadata: () => {},
+      ask: async () => {},
+      directory: '/tmp',
+      worktree: '/tmp',
+    }
+
+    beforeEach(() => {
+      expect(sessionUpdateCallbacks).toHaveLength(0)
+    })
+
+    it('returns a complete <pty_waited> block for an exited session', async () => {
+      spyOn(manager, 'get').mockReturnValue(makeSession())
+      spyOn(manager, 'read').mockReturnValue({
+        lines: ['build succeeded', 'server started'],
+        offset: 0,
+        hasMore: false,
+        totalLines: 2,
+      })
+
+      const result = await ptyWait.execute({ id: 'test-session-id' }, ctx)
+
+      expect(result).toContain('<pty_waited>')
+      expect(result).toContain('ID: test-session-id')
+      expect(result).toContain('Title: Test Session')
+      expect(result).toContain('Command: echo hello')
+      expect(result).toContain('Status: exited')
+      expect(result).toContain('Exit: 0')
+      expect(result).toContain('Output Lines: 2')
+      expect(result).toContain('</pty_waited>')
+      expect(sessionUpdateCallbacks).toHaveLength(0)
+    })
+
+    it('includes a tail of the last 20 buffer lines', async () => {
+      spyOn(manager, 'get').mockReturnValue(makeSession({ lineCount: 25 }))
+      spyOn(manager, 'read').mockReturnValue({
+        lines: ['line 6', 'line 7', 'line 8'],
+        offset: 5,
+        hasMore: false,
+        totalLines: 25,
+      })
+
+      const result = await ptyWait.execute({ id: 'test-session-id' }, ctx)
+
+      expect(manager.read).toHaveBeenCalledWith('test-session-id', 5, 20)
+      expect(result).toContain('00006| line 6')
+      expect(result).toContain('00007| line 7')
+      expect(sessionUpdateCallbacks).toHaveLength(0)
+    })
+
+    it('waits for a running session until it exits', async () => {
+      spyOn(manager, 'get').mockReturnValue(makeSession({ status: 'running', exitCode: undefined }))
+      spyOn(manager, 'read').mockReturnValue({
+        lines: [],
+        offset: 0,
+        hasMore: false,
+        totalLines: 0,
+      })
+
+      const pending = ptyWait.execute({ id: 'test-session-id' }, ctx)
+      expect(sessionUpdateCallbacks).toHaveLength(1)
+
+      const callback = sessionUpdateCallbacks[0]
+      if (!callback) {
+        throw new Error('ptyWait did not register a session update callback')
+      }
+      callback(makeSession())
+
+      const result = await pending
+
+      expect(result).toContain('Status: exited')
+      expect(result).toContain('Exit: 0')
+      expect(result).toContain('</pty_waited>')
+      expect(sessionUpdateCallbacks).toHaveLength(0)
+    })
+
+    it('returns <pty_wait_timeout> when the session stays running past timeoutSeconds', async () => {
+      spyOn(manager, 'get').mockReturnValue(makeSession({ status: 'running', exitCode: undefined }))
+
+      const result = await ptyWait.execute({ id: 'test-session-id', timeoutSeconds: 0.05 }, ctx)
+
+      expect(result).toContain('<pty_wait_timeout>')
+      expect(result).toContain('still running after 0.05s')
+      expect(result).toContain('</pty_wait_timeout>')
+      expect(sessionUpdateCallbacks).toHaveLength(0)
+    })
+
+    it('reports the exit signal when no exit code is present', async () => {
+      spyOn(manager, 'get').mockReturnValue(
+        makeSession({ exitCode: undefined, exitSignal: 15, lineCount: 0 })
+      )
+      spyOn(manager, 'read').mockReturnValue({
+        lines: [],
+        offset: 0,
+        hasMore: false,
+        totalLines: 0,
+      })
+
+      const result = await ptyWait.execute({ id: 'test-session-id' }, ctx)
+
+      expect(result).toContain('Exit: unknown, signal: 15')
+      expect(result).not.toContain('Tail:')
+      expect(sessionUpdateCallbacks).toHaveLength(0)
+    })
+
+    it('throws when the session does not exist', async () => {
+      spyOn(manager, 'get').mockReturnValue(null)
+
+      expect(ptyWait.execute({ id: 'missing-session' }, ctx)).rejects.toThrow(
+        "PTY session 'missing-session' not found"
+      )
+      expect(sessionUpdateCallbacks).toHaveLength(0)
     })
   })
 


### PR DESCRIPTION
## Summary

- Add a `pty_wait` tool that blocks until a PTY session finishes running, with an optional `timeoutSeconds`.
- Returns a `<pty_waited>` block with final status, exit code/signal, output line count, and the last 20 lines of output; returns a `<pty_wait_timeout>` block instead of blocking forever when the timeout elapses.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f72f4c99-0bc1-446f-bc44-0d139ac1f4c5" />

## Motivation

Exit notifications (`notifyOnExit` → `<pty_exited>`) require the agent to go idle and wait for the injected message. This is unreliable when:

- A subagent goes idle waiting for `<pty_exited>` and the parent interprets idleness as task completion.
- A `/goal` plugin auto-resumes idle agents, so an agent idling to wait for `<pty_exited>` gets repeatedly resumed.

`pty_wait` gives the agent a synchronous blocking alternative in both scenarios.

## Changes

- `src/plugin/pty/tools/wait.ts`: new tool: one-shot session-update callback raced against an optional timeout (`Promise.race`), closing the register/exit race window
- `src/plugin/pty/tools/wait.txt`: tool description
- `src/plugin.ts`: registers `pty_wait` alongside the other `pty_*` tools
- `src/plugin/pty/manager.ts`:: iterate a snapshot of `sessionUpdateCallbacks` so a callback removing itself mid-iteration can't skip other subscribers (e.g. the web UI's WS broadcast)
- `README.md`: tools table row + a "Wait for a session to finish" section
- `test/pty-tools.test.ts`: `ptyWait` suite: already-exited, tail window, callback-driven exit, timeout, exit-signal, not-found, plus callback-leak hygiene

## Verification

- `bun lint`
- `bun format`
- `bun run typecheck`
- `bun unittest` (73 passed, 1 skipped)